### PR TITLE
Make the patch command work when building on EL6

### DIFF
--- a/tomcat-7.0.70-CompilerOptionsV8.patch
+++ b/tomcat-7.0.70-CompilerOptionsV8.patch
@@ -1,43 +1,43 @@
---- java/org/apache/jasper/compiler/JDTCompiler.java~	2016-06-16 09:53:52.793827761 -0400
-+++ java/org/apache/jasper/compiler/JDTCompiler.java	2016-06-16 09:59:29.809134932 -0400
-@@ -67,7 +67,6 @@ public class JDTCompiler extends org.apa
+--- java/org/apache/jasper/compiler/JDTCompiler.java~   2016-06-16 09:53:52.793827761 -0400
++++ java/org/apache/jasper/compiler/JDTCompiler.java    2016-06-16 09:59:29.809134932 -0400
+@@ -67,7 +67,6 @@
      /** 
       * Compile the servlet from .java file to .class file
       */
 -    @Override
      protected void generateClass(String[] smap)
          throws FileNotFoundException, JasperException, Exception {
-
-@@ -98,12 +97,10 @@ public class JDTCompiler extends org.apa
+ 
+@@ -98,12 +97,10 @@
                  this.sourceFile = sourceFile;
              }
-
+ 
 -            @Override
              public char[] getFileName() {
                  return sourceFile.toCharArray();
              }
-
+             
 -            @Override
              public char[] getContents() {
                  char[] result = null;
                  FileInputStream is = null;
-@@ -145,7 +142,6 @@ public class JDTCompiler extends org.apa
+@@ -145,7 +142,6 @@
                  return result;
              }
-
+             
 -            @Override
              public char[] getMainTypeName() {
                  int dot = className.lastIndexOf('.');
                  if (dot > 0) {
-@@ -154,7 +150,6 @@ public class JDTCompiler extends org.apa
+@@ -154,7 +150,6 @@
                  return className.toCharArray();
              }
-
+             
 -            @Override
              public char[][] getPackageName() {
                  StringTokenizer izer = 
                      new StringTokenizer(className, ".");
-@@ -166,7 +161,6 @@ public class JDTCompiler extends org.apa
+@@ -166,7 +161,6 @@
                  return result;
              }
  
@@ -45,7 +45,7 @@
              public boolean ignoreOptionalProblems() {
                  return false;
              }
-@@ -174,7 +168,6 @@ public class JDTCompiler extends org.apa
+@@ -174,7 +168,6 @@
  
          final INameEnvironment env = new INameEnvironment() {
  
@@ -53,7 +53,7 @@
                  public NameEnvironmentAnswer 
                      findType(char[][] compoundTypeName) {
                      StringBuilder result = new StringBuilder();
-@@ -187,7 +180,6 @@ public class JDTCompiler extends org.apa
+@@ -187,7 +180,6 @@
                      return findType(result.toString());
                  }
  
@@ -61,15 +61,15 @@
                  public NameEnvironmentAnswer 
                      findType(char[] typeName, 
                               char[][] packageName) {
-@@ -269,7 +261,6 @@ public class JDTCompiler extends org.apa
+@@ -269,7 +261,6 @@
                      }
                  }
-
+ 
 -                @Override
                  public boolean isPackage(char[][] parentPackageName, 
                                           char[] packageName) {
                      StringBuilder result = new StringBuilder();
-@@ -291,7 +282,6 @@ public class JDTCompiler extends org.apa
+@@ -291,7 +282,6 @@
                      return isPackage(result.toString());
                  }
  
@@ -77,7 +77,7 @@
                  public void cleanup() {
                  }
  
-@@ -340,9 +330,6 @@ public class JDTCompiler extends org.apa
+@@ -340,9 +330,6 @@
              } else if(opt.equals("1.7")) {
                  settings.put(CompilerOptions.OPTION_Source,
                               CompilerOptions.VERSION_1_7);
@@ -87,7 +87,7 @@
              } else {
                  log.warn("Unknown source VM " + opt + " ignored.");
                  settings.put(CompilerOptions.OPTION_Source,
-@@ -384,11 +371,6 @@ public class JDTCompiler extends org.apa
+@@ -384,11 +371,6 @@
                               CompilerOptions.VERSION_1_7);
                  settings.put(CompilerOptions.OPTION_Compliance,
                          CompilerOptions.VERSION_1_7);
@@ -99,9 +99,9 @@
              } else {
                  log.warn("Unknown target VM " + opt + " ignored.");
                  settings.put(CompilerOptions.OPTION_TargetPlatform,
-@@ -406,7 +388,6 @@ public class JDTCompiler extends org.apa
+@@ -406,7 +388,6 @@
              new DefaultProblemFactory(Locale.getDefault());
-
+         
          final ICompilerRequestor requestor = new ICompilerRequestor() {
 -                @Override
                  public void acceptResult(CompilationResult result) {


### PR DESCRIPTION
PATCH command on EL6 does not support "Inline Function name" as generated by

  diff -p

This change revert to "old style" diff to make patch work when building rpm on EL6